### PR TITLE
Make code buildable (no crash-and-burn in "lein package")

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,9 +5,9 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.9.0-alpha6"] ; match version needed by other dat* bits
-                 [org.clojure/tools.reader "1.0.0-beta2"]
+                 [org.clojure/tools.reader "1.0.0-beta3"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [org.clojure/clojurescript "1.9.36"]
+                 [org.clojure/clojurescript "1.9.293"]
                  [commons-codec "1.10"]
 
                  [datreactor "0.0.1-alpha1-SNAPSHOT"]
@@ -15,29 +15,29 @@
 
                  ;; Do we need this?
                  [org.clojure/core.async "0.2.395"]
-                 [com.stuartsierra/component "0.3.1"]
+                 [com.stuartsierra/component "0.3.2"]
 
-                 [environ "1.0.1"]
+                 [environ "1.1.0"]
 
-                 [reagent "0.5.1"]
-                 [re-frame "0.5.0"]
+                 [reagent "0.6.0"]
+                 ;[re-frame "0.9.1"]
                  [posh "0.5.5"]
-                 [datascript "0.15.0"]
+                 [datascript "0.15.5"]
 
-                 [com.taoensso/timbre "4.7.4"]
+                 [com.taoensso/timbre "4.8.0"]
                  [com.taoensso/sente "1.11.0"]
-                 [com.taoensso/encore "2.88.1"]
-                 [com.cognitect/transit-clj "0.8.290"]
+                 [com.taoensso/encore "2.88.2"]
+                 [com.cognitect/transit-clj "0.8.297"]
                  [com.cognitect/transit-cljs "0.8.239"]
 
                  ;; Server db (datomic)
-                 [com.datomic/datomic-free "0.9.5327" :exclusions [joda-time com.google.guava/guava]]
+                 [com.datomic/datomic-free "0.9.5544" :exclusions [joda-time com.google.guava/guava]]
 
                  ;; Not sure if we need; probably not... XXX
-                 [bidi "1.21.1"]
+                 [bidi "2.0.16"]
                  [io.rkn/conformity "0.4.0"]
-                 [com.rpl/specter "0.9.1"]
-                 [prismatic/plumbing "0.5.2"]
+                 [com.rpl/specter "0.13.2"]
+                 [prismatic/plumbing "0.5.3"]
                  [org.clojure/core.match "0.3.0-alpha4"]]
 
                  ;; XXX For when we jump aboard.

--- a/project.clj
+++ b/project.clj
@@ -4,26 +4,29 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "1.7.145"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha6"] ; match version needed by other dat* bits
+                 [org.clojure/tools.reader "1.0.0-beta2"]
                  [org.clojure/tools.logging "0.3.1"]
+                 [org.clojure/clojurescript "1.9.36"]
+                 [commons-codec "1.10"]
 
                  [datreactor "0.0.1-alpha1-SNAPSHOT"]
                  [datspec "0.0.1-alpha1-SNAPSHOT"]
 
                  ;; Do we need this?
-                 [org.clojure/core.async "0.2.371"]
-                 [com.stuartsierra/component "0.3.0"]
+                 [org.clojure/core.async "0.2.395"]
+                 [com.stuartsierra/component "0.3.1"]
 
                  [environ "1.0.1"]
 
                  [reagent "0.5.1"]
                  [re-frame "0.5.0"]
-                 [posh "0.3.4"]
-                 [datascript "0.13.3"]
+                 [posh "0.5.5"]
+                 [datascript "0.15.0"]
 
-                 [com.taoensso/timbre "4.7.0"]
-                 [com.taoensso/sente "1.8.1"]
+                 [com.taoensso/timbre "4.7.4"]
+                 [com.taoensso/sente "1.11.0"]
+                 [com.taoensso/encore "2.88.1"]
                  [com.cognitect/transit-clj "0.8.290"]
                  [com.cognitect/transit-cljs "0.8.239"]
 

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,10 @@
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.145"]
+                 [org.clojure/tools.logging "0.3.1"]
+
+                 [datreactor "0.0.1-alpha1-SNAPSHOT"]
+                 [datspec "0.0.1-alpha1-SNAPSHOT"]
 
                  ;; Do we need this?
                  [org.clojure/core.async "0.2.371"]
@@ -15,11 +19,16 @@
 
                  [reagent "0.5.1"]
                  [re-frame "0.5.0"]
-                 [posh "0.3.3.1"]
+                 [posh "0.3.4"]
                  [datascript "0.13.3"]
 
+                 [com.taoensso/timbre "4.7.0"]
+                 [com.taoensso/sente "1.8.1"]
+                 [com.cognitect/transit-clj "0.8.290"]
+                 [com.cognitect/transit-cljs "0.8.239"]
+
                  ;; Server db (datomic)
-                 [com.datomic/datomic-free "0.9.5327" :exclusions [joda-time]]
+                 [com.datomic/datomic-free "0.9.5327" :exclusions [joda-time com.google.guava/guava]]
 
                  ;; Not sure if we need; probably not... XXX
                  [bidi "1.21.1"]
@@ -43,7 +52,7 @@
   :cljsbuild { 
               :builds [
                        { :id "release"
-                         :source-paths ["src" "bench/src"]
+                         :source-paths ["src"]
                          :assert false
                          :compiler {
                                     :output-to     "release-js/datsync.bare.js"
@@ -59,7 +68,7 @@
 
   :profiles {
              :dev {
-                   :source-paths ["bench/src" "test" "dev" "src"]
+                   :source-paths ["test" "dev" "src"]
                    :plugins [
                              [lein-cljsbuild "1.1.2"]
                              [lein-typed "0.3.5"]]
@@ -67,7 +76,7 @@
                    :cljsbuild {
                                :builds [
                                         { :id "advanced"
-                                          :source-paths ["src" "bench/src" "test"]
+                                          :source-paths ["src" "test"]
                                           :compiler {
                                                      :output-to     "target/datsync.js"
                                                      :optimizations :advanced
@@ -77,7 +86,7 @@
                                                      :parallel-build true}}
 
                                         { :id "none"
-                                          :source-paths ["src" "bench/src" "test" "dev"]
+                                          :source-paths ["src" "test" "dev"]
                                           :compiler {
                                                      :main          datsync.test
                                                      :output-to     "target/datsync.js"

--- a/src/dat/remote/impl/sente.cljc
+++ b/src/dat/remote/impl/sente.cljc
@@ -7,7 +7,6 @@
             [dat.sync.utils :as utils]
             [dat.spec.protocols :as protocols]
             [com.stuartsierra.component :as component]
-            [cognitect.transit] ;; undeclared dependency of sente
             [taoensso.timbre :as log #?@(:cljs [:include-macros true])]
             [taoensso.sente :as sente]
             [taoensso.sente.packers.transit :as sente-transit]))
@@ -29,7 +28,7 @@
   (start [component]
     (log/info "Starting SenteRemote Component")
     (let [out-chan (or out-chan (async/chan 100))
-          packer (sente-transit/get-flexi-packer :edn)
+          packer (sente-transit/get-transit-packer)
           sente-fns (sente/make-channel-socket! "/chsk" {:type :auto :packer packer})
           ch-recv (:ch-recv sente-fns)]
       ;; Set Sente to pipe it's events such that they all (at the top level) fit the standard re-frame shape

--- a/src/dat/remote/impl/sente.cljc
+++ b/src/dat/remote/impl/sente.cljc
@@ -7,6 +7,7 @@
             [dat.sync.utils :as utils]
             [dat.spec.protocols :as protocols]
             [com.stuartsierra.component :as component]
+            [cognitect.transit] ;; undeclared dependency of sente
             [taoensso.timbre :as log #?@(:cljs [:include-macros true])]
             [taoensso.sente :as sente]
             [taoensso.sente.packers.transit :as sente-transit]))


### PR DESCRIPTION
Add missing dependencies, kill bad source-paths, require cognitect.transit before taoensso.sente.packers.transit

Related: metasoarous/datview#12