### PR TITLE
Bumped version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ But for the sake of thoroughness, we'll cover here how you'd set things up.
 First, add the following to your `project.clj`:
 
 ```
-[datsync "0.0.1-alpha2-SNAPSHOT"]
+[datsync "0.0.1-alpha3"]
 ```
 
 


### PR DESCRIPTION
I was unable to import dat.sync.client/base-schema (line 71) from version 0.0.1-alpha2-SNAPSHOT